### PR TITLE
Remove RVMViewModel.model

### DIFF
--- a/ReactiveViewModel/RVMViewModel.h
+++ b/ReactiveViewModel/RVMViewModel.h
@@ -10,12 +10,9 @@
 
 @class RACSignal;
 
-// Adapts a domain model to be user-presentable, and implements behaviors that
-// drive the UI.
+// Implements behaviors that drive the UI, and/or adapts a domain model to be
+// user-presentable.
 @interface RVMViewModel : NSObject
-
-// The model which the view model is adapting for the UI.
-@property (nonatomic, readonly, strong) id model;
 
 // Whether the view model is currently "active."
 //
@@ -38,16 +35,6 @@
 // If the receiver is currently inactive, this signal will send once immediately
 // upon subscription.
 @property (nonatomic, strong, readonly) RACSignal *didBecomeInactiveSignal;
-
-// Calls -initWithModel: with a nil model.
-- (instancetype)init;
-
-// Creates a new view model with the given model.
-//
-// model - The model to adapt for the UI. This argument may be nil.
-//
-// Returns an initialized view model, or nil if an error occurs.
-- (instancetype)initWithModel:(id)model;
 
 // Subscribes (or resubscribes) to the given signal whenever
 // `didBecomeActiveSignal` fires.

--- a/ReactiveViewModel/RVMViewModel.m
+++ b/ReactiveViewModel/RVMViewModel.m
@@ -80,21 +80,6 @@ static const NSTimeInterval RVMViewModelInactiveThrottleInterval = 1;
 	return _didBecomeInactiveSignal;
 }
 
-#pragma mark Lifecycle
-
-- (id)init {
-	return [self initWithModel:nil];
-}
-
-- (id)initWithModel:(id)model {
-	self = [super init];
-	if (self == nil) return nil;
-
-	_model = model;
-
-	return self;
-}
-
 #pragma mark Activation
 
 - (RACSignal *)forwardSignalWhileActive:(RACSignal *)signal {

--- a/ReactiveViewModelTests/RVMViewModelSpec.m
+++ b/ReactiveViewModelTests/RVMViewModelSpec.m
@@ -13,7 +13,7 @@ SpecBegin(RVMViewModel)
 __block RVMTestViewModel *viewModel;
 
 beforeEach(^{
-	viewModel = [[RVMTestViewModel alloc] initWithModel:@"foobar"];
+	viewModel = [[RVMTestViewModel alloc] init];
 });
 
 describe(@"active property", ^{
@@ -79,7 +79,7 @@ describe(@"active property", ^{
 			deallocated = NO;
 
 			createViewModel = ^{
-				RVMTestViewModel *viewModel = [[RVMTestViewModel alloc] initWithModel:nil];
+				RVMTestViewModel *viewModel = [[RVMTestViewModel alloc] init];
 				[viewModel.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
 					deallocated = YES;
 				}]];


### PR DESCRIPTION
I've seen a lot of cases now where there's no sensible `model` for an `RVMViewModel` subclass, so there's little reason to have it declared on the base class. `RVMViewModel` doesn't even _do_ anything with it.
