### PR TITLE
inject protocol RVMViewModelReacting for using in couple RVMViewModel

### DIFF
--- a/ReactiveViewModel.xcodeproj/project.pbxproj
+++ b/ReactiveViewModel.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		D4ACA4DA18DB97D000EBD899 /* libSpecta.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D4ACA4D918DB97D000EBD899 /* libSpecta.a */; };
 		D4ACA4DE18DB97DC00EBD899 /* libExpecta-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D4ACA4DD18DB97DC00EBD899 /* libExpecta-iOS.a */; };
 		D4ACA4DF18DB980500EBD899 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4ACA4D118DB97A000EBD899 /* ReactiveCocoa.framework */; };
+		F0BDE8F919199B7D00F6998F /* RVMViewModelReacting.h in Headers */ = {isa = PBXBuildFile; fileRef = F0BDE8F819199B7D00F6998F /* RVMViewModelReacting.h */; };
+		F0BDE8FA19199B7D00F6998F /* RVMViewModelReacting.h in Headers */ = {isa = PBXBuildFile; fileRef = F0BDE8F819199B7D00F6998F /* RVMViewModelReacting.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -97,6 +99,7 @@
 		D4ACA4D718DB97BA00EBD899 /* libSpecta-iOS.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libSpecta-iOS.a"; path = "External/ReactiveCocoa/external/specta/build/Debug-iphoneos/libSpecta-iOS.a"; sourceTree = "<group>"; };
 		D4ACA4D918DB97D000EBD899 /* libSpecta.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSpecta.a; path = External/ReactiveCocoa/external/specta/build/Debug/libSpecta.a; sourceTree = "<group>"; };
 		D4ACA4DD18DB97DC00EBD899 /* libExpecta-iOS.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libExpecta-iOS.a"; path = "External/ReactiveCocoa/external/expecta/build/Debug-iphoneos/libExpecta-iOS.a"; sourceTree = "<group>"; };
+		F0BDE8F819199B7D00F6998F /* RVMViewModelReacting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RVMViewModelReacting.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -190,6 +193,7 @@
 			isa = PBXGroup;
 			children = (
 				D0948A4B178159AD00BA8F23 /* ReactiveViewModel.h */,
+				F0BDE8F719199B4600F6998F /* Protocol */,
 				D0948B4A178160FC00BA8F23 /* View Model */,
 				D0948A45178159AD00BA8F23 /* Supporting Files */,
 			);
@@ -308,6 +312,14 @@
 			name = "View Model";
 			sourceTree = "<group>";
 		};
+		F0BDE8F719199B4600F6998F /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				F0BDE8F819199B7D00F6998F /* RVMViewModelReacting.h */,
+			);
+			name = Protocol;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -316,6 +328,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D0948ABA17815AF100BA8F23 /* ReactiveViewModel.h in Headers */,
+				F0BDE8F919199B7D00F6998F /* RVMViewModelReacting.h in Headers */,
 				D0948B551781610600BA8F23 /* RVMViewModel.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -325,6 +338,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D0948ABB17815AF100BA8F23 /* ReactiveViewModel.h in Headers */,
+				F0BDE8FA19199B7D00F6998F /* RVMViewModelReacting.h in Headers */,
 				D0948B561781610600BA8F23 /* RVMViewModel.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ReactiveViewModel/RVMViewModel.h
+++ b/ReactiveViewModel/RVMViewModel.h
@@ -7,55 +7,10 @@
 //
 
 #import <Foundation/Foundation.h>
-
-@class RACSignal;
+#import "RVMViewModelReacting.h"
 
 // Implements behaviors that drive the UI, and/or adapts a domain model to be
 // user-presentable.
-@interface RVMViewModel : NSObject
-
-// Whether the view model is currently "active."
-//
-// This generally implies that the associated view is visible. When set to NO,
-// the view model should throttle or cancel low-priority or UI-related work.
-//
-// This property defaults to NO.
-@property (nonatomic, assign, getter = isActive) BOOL active;
-
-// Observes the receiver's `active` property, and sends the receiver whenever it
-// changes from NO to YES.
-//
-// If the receiver is currently active, this signal will send once immediately
-// upon subscription.
-@property (nonatomic, strong, readonly) RACSignal *didBecomeActiveSignal;
-
-// Observes the receiver's `active` property, and sends the receiver whenever it
-// changes from YES to NO.
-//
-// If the receiver is currently inactive, this signal will send once immediately
-// upon subscription.
-@property (nonatomic, strong, readonly) RACSignal *didBecomeInactiveSignal;
-
-// Subscribes (or resubscribes) to the given signal whenever
-// `didBecomeActiveSignal` fires.
-//
-// When `didBecomeInactiveSignal` fires, any active subscription to `signal` is
-// disposed.
-//
-// Returns a signal which forwards `next`s from the latest subscription to
-// `signal`, and completes when the receiver is deallocated. If `signal` sends
-// an error at any point, the returned signal will error out as well.
-- (RACSignal *)forwardSignalWhileActive:(RACSignal *)signal;
-
-// Throttles events on the given signal while the receiver is inactive.
-//
-// Unlike -forwardSignalWhileActive:, this method will stay subscribed to
-// `signal` the entire time, except that its events will be throttled when the
-// receiver becomes inactive.
-//
-// Returns a signal which forwards events from `signal` (throttled while the
-// receiver is inactive), and completes when `signal` completes or the receiver
-// is deallocated.
-- (RACSignal *)throttleSignalWhileInactive:(RACSignal *)signal;
+@interface RVMViewModel : NSObject <RVMViewModelReacting>
 
 @end

--- a/ReactiveViewModel/RVMViewModel.m
+++ b/ReactiveViewModel/RVMViewModel.m
@@ -30,8 +30,10 @@ static const NSTimeInterval RVMViewModelInactiveThrottleInterval = 1;
 
 // We create many, many view models, so these properties need to be as lazy and
 // memory-conscious as possible.
-@synthesize didBecomeActiveSignal = _didBecomeActiveSignal;
+@synthesize didBecomeActiveSignal   = _didBecomeActiveSignal;
 @synthesize didBecomeInactiveSignal = _didBecomeInactiveSignal;
+
+@synthesize active                  = _active;
 
 - (void)setActive:(BOOL)active {
 	// Skip KVO notifications when the property hasn't actually changed. This is

--- a/ReactiveViewModel/RVMViewModelReacting.h
+++ b/ReactiveViewModel/RVMViewModelReacting.h
@@ -1,0 +1,59 @@
+//
+//  RVMViewModelReacting.h
+//  ReactiveViewModel
+//
+//  Created by Eduard Beleninik on 5/7/14.
+//  Copyright (c) 2014 GitHub. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class RACSignal;
+
+@protocol RVMViewModelReacting <NSObject>
+
+// Whether the view model is currently "active."
+//
+// This generally implies that the associated view is visible. When set to NO,
+// the view model should throttle or cancel low-priority or UI-related work.
+//
+// This property defaults to NO.
+@property (nonatomic, assign, getter = isActive) BOOL active;
+
+// Observes the receiver's `active` property, and sends the receiver whenever it
+// changes from NO to YES.
+//
+// If the receiver is currently active, this signal will send once immediately
+// upon subscription.
+@property (nonatomic, strong, readonly) RACSignal *didBecomeActiveSignal;
+
+// Observes the receiver's `active` property, and sends the receiver whenever it
+// changes from YES to NO.
+//
+// If the receiver is currently inactive, this signal will send once immediately
+// upon subscription.
+@property (nonatomic, strong, readonly) RACSignal *didBecomeInactiveSignal;
+
+// Subscribes (or resubscribes) to the given signal whenever
+// `didBecomeActiveSignal` fires.
+//
+// When `didBecomeInactiveSignal` fires, any active subscription to `signal` is
+// disposed.
+//
+// Returns a signal which forwards `next`s from the latest subscription to
+// `signal`, and completes when the receiver is deallocated. If `signal` sends
+// an error at any point, the returned signal will error out as well.
+- (RACSignal *)forwardSignalWhileActive:(RACSignal *)signal;
+
+// Throttles events on the given signal while the receiver is inactive.
+//
+// Unlike -forwardSignalWhileActive:, this method will stay subscribed to
+// `signal` the entire time, except that its events will be throttled when the
+// receiver becomes inactive.
+//
+// Returns a signal which forwards events from `signal` (throttled while the
+// receiver is inactive), and completes when `signal` completes or the receiver
+// is deallocated.
+- (RACSignal *)throttleSignalWhileInactive:(RACSignal *)signal;
+
+@end

--- a/ReactiveViewModel/ReactiveViewModel.h
+++ b/ReactiveViewModel/ReactiveViewModel.h
@@ -7,3 +7,4 @@
 //
 
 #import "RVMViewModel.h"
+#import "RVMViewModelReacting.h"


### PR DESCRIPTION
Please, review request to inject protocol

Recently I faced to using multiple ViewModels with one common protocol. And you know, I don't understand why not use protocol to avoid some writting like `RVMViewModel <MyProtocol> *viewModel`. Because, in this case a ViewController doesn't may find anything from `RVMViewModel`

for example:

``` objective-c
@protocol MyProtocol <NSObject>

@interface MyClass1VM: RVMViewModel <MyProtocol>
@interface MyClass2VM: RVMViewModel <MyProtocol>
```

thus, we get next ...

``` objective-c
@interface MyCustomVC : UIViewController
@property (nonatomic, strong) RVMViewModel <MyProtocol> *viewModel
@end
```

Perhaps, better to use in this case a protocol inheritance

``` objective-c
@protocol MyProtocol <NSObject, RVMViewModelReacting>
```
