### PR TITLE
Pacify Xcode

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
-github "jspahrsummers/xcconfigs" >= 0.7
+github "jspahrsummers/xcconfigs" >= 0.7.1
 github "Quick/Quick" ~> 0.2
 github "Quick/Nimble" ~> 0.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "Quick/Nimble" "v0.2.0"
 github "Quick/Quick" "v0.2.2"
 github "ReactiveCocoa/ReactiveCocoa" "v2.4.3"
-github "jspahrsummers/xcconfigs" "0.7"
+github "jspahrsummers/xcconfigs" "0.7.1"

--- a/ReactiveViewModel.xcodeproj/project.pbxproj
+++ b/ReactiveViewModel.xcodeproj/project.pbxproj
@@ -415,7 +415,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastTestingUpgradeCheck = 0510;
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 0620;
 				ORGANIZATIONNAME = GitHub;
 				TargetAttributes = {
 					D0C7C3A619FEFB520069B5C0 = {
@@ -536,6 +536,7 @@
 			buildSettings = {
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;

--- a/ReactiveViewModel.xcodeproj/xcshareddata/xcschemes/ReactiveViewModel Mac.xcscheme
+++ b/ReactiveViewModel.xcodeproj/xcshareddata/xcschemes/ReactiveViewModel Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0620"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ReactiveViewModel.xcodeproj/xcshareddata/xcschemes/ReactiveViewModel iOS.xcscheme
+++ b/ReactiveViewModel.xcodeproj/xcshareddata/xcschemes/ReactiveViewModel iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0620"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
For https://github.com/jspahrsummers/xcconfigs/pull/32.

And I know what you’re thinking, “But `ONLY_ACTIVE_ARCH` is already in the xcconfig!” Yes. Well. Xcode.